### PR TITLE
fix: change default quality to 75 from 73

### DIFF
--- a/src/lib/components/Image.svelte
+++ b/src/lib/components/Image.svelte
@@ -9,7 +9,7 @@
   let klass: string | undefined = undefined
   export { klass as class }
 
-  export let quality: number = 73
+  export let quality: number = 75
 
   export let loader: Loader = (src, width, quality) =>
     `/api/_image?${new URLSearchParams({


### PR DESCRIPTION
I'm assuming that this value was supposed to be 75 since that's what Next.js uses and 73 is a really random number