### PR TITLE
fix: add reactivity to svelte component

### DIFF
--- a/.changeset/odd-shirts-play.md
+++ b/.changeset/odd-shirts-play.md
@@ -1,0 +1,5 @@
+---
+"@urami/svelte": patch
+---
+
+add reactivity to svelte image component

--- a/packages/svelte/src/Image.svelte
+++ b/packages/svelte/src/Image.svelte
@@ -14,7 +14,7 @@
 
   export let loader: Loader = defaultLoader
 
-  const buildProps = buildSource(loader, src, width, quality)
+  $: buildProps = buildSource(loader, src, width, quality)
 </script>
 
 <!-- svelte-ignore a11y-missing-attribute -->


### PR DESCRIPTION
Currently, the Svelte component is missing reactivity. Meaning that if the source changes the image won't be updated.
I'm not sure if this is intended or not but my use case require this reactivity so I open this PR.